### PR TITLE
LININTERNL-3563 Update the zlib download URL

### DIFF
--- a/thirdparty/versions.sh
+++ b/thirdparty/versions.sh
@@ -15,5 +15,5 @@ GTEST_URL="https://github.com/google/googletest/archive/release-${GTEST_VERSION}
 GTEST_BASEDIR=googletest-release-$GTEST_VERSION
 
 ZLIB_VERSION=1.2.8
-ZLIB_URL=http://zlib.net/zlib-${ZLIB_VERSION}.tar.gz
+ZLIB_URL=http://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz
 ZLIB_BASEDIR=zlib-${ZLIB_VERSION}


### PR DESCRIPTION
This is already fixed upstream but I don't want to upgrade the upstream at the moment.

Tested using this script:

(on linear dev machines, you woud need this as well:
```
export CC =  /opt/rh/devtoolset-2/root/usr/bin/gcc
export CXX =  /opt/rh/devtoolset-2/root/usr/bin/g++
export PARQUET_GCC_ROOT = /opt/rh/devtoolset-2/root/usr
```
)


```
./thirdparty/download_thirdparty.sh
for dep in zlib gtest snappy thrift ; do ./thirdparty/build_thirdparty.sh $dep ; done
source thirdparty/set_thirdparty_env.sh
rm -f CMakeCache.txt
cmake -DBoost_NO_BOOST_CMAKE=TRUE -DBOOST_INCLUDEDIR=/usr/include/boost159 -DBOOST_LIBRARYDIR=/usr/lib64/boost159 -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_CXX_FLAGS=-msse4.2  .
make
```
